### PR TITLE
회원가입, 로그인, 로그아웃 api 구현

### DIFF
--- a/server/apis/auth.py
+++ b/server/apis/auth.py
@@ -1,0 +1,65 @@
+from flask import Blueprint, url_for, render_template, flash, request, session, g, jsonify
+from werkzeug.security import generate_password_hash, check_password_hash
+from werkzeug.utils import redirect
+
+import functools
+
+
+from module.database import Database;
+import module.error_handler
+
+bp = Blueprint('auth', __name__, url_prefix='/auth')
+
+@bp.route('/signup/', methods=('POST'))
+def signup():
+    if request.method == 'POST':
+        id = request.form['id']
+        password = request.form['password']
+        nickname = request.form['nickname']
+
+        db = Database()
+
+        try:
+            # user 테이블 생성
+            sql='''
+            CREATE TABLE IF NOT EXISTS `user` (
+            `id` VARCHAR(30) NOT NULL,
+            `password` VARCHAR(30) NOT NULL,
+            `nickname` VARCHAR(30) NOT NULL,
+            PRIMARY KEY (`user_id`));
+            '''
+            db.execute(sql)
+            db.commit()
+
+            # 회원가입시 새로운 유저 정보 등록
+            sql = '''INSERT INTO user_tb VALUES (%s,%s,%s);'''
+
+            db.execute(sql,(id,password,nickname))
+            db.commit()
+        except:
+            return module.error_handler.errer_message("Bad Request")
+
+
+@bp.route('/login/', methods=('POST'))
+def login():
+    if request.method == 'POST':
+        id = request.form['id']
+        password = request.form['password']
+
+        db = Database()
+
+        sql = '''SELECT * user WHERE id = %s and password = %s;'''
+
+        user_info = db.execute_one(sql, (id, password))
+
+        db.commit()
+
+        return jsonify(user_info)
+
+@bp.route('/logout/', methods=('POST'))
+def logout():
+    try:
+        session.clear()
+        return module.error_handler.success_message("OK")
+    except:
+        return module.error_handler.errer_message("Bad Request")


### PR DESCRIPTION
## Related Issues
api명세서에 맞게 회원가입, 로그인, 로그아웃 api 구현했습니다.

## Description
1. /signup [POST]: user테이블에 id, password, nickname을 저장합니다.
![image](https://github.com/0NYE/FPS-backend/assets/82487512/ab58f722-18d9-4ca5-b887-b1500fdd2400)

2. /login [POST]: user테이블에서 id, password가 일치한 유저를 JSON으로 가져옵니다.
![image](https://github.com/0NYE/FPS-backend/assets/82487512/dfdcd3ad-c76d-42cb-bce8-88cf85d7a559)

3. /logout [POST]: 세션을 클리어합니다.
![image](https://github.com/0NYE/FPS-backend/assets/82487512/b710fa81-561f-4fee-b0ae-ed0de5374680)

## To Reviewer
로그인 api에서 아이디, 패스워드가 일지하는 유저를 가져오는 쿼리문을 작성할때 db.execute_one 메소드를 쓰는 것이 맞는 지 확인 부탁드립니다.
